### PR TITLE
refactor: changed the logger tag

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -107,7 +107,7 @@ func Config(params ...interface{}) (map[string]string, error) {
 
 	if len(params) == 0 {
 		filename = ".env"
-		logger = log.New(os.Stderr, "Dotenv logger", log.LstdFlags)
+		logger = log.New(os.Stderr, "dotenv", log.LstdFlags)
 	}
 
 	envVars, err := load(filename)


### PR DESCRIPTION
This changes the default log tag from "Dotenv logger" to "dotenv".