### PR TITLE
fix: updated env parsing algo to use splitn instead of split

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -22,9 +22,9 @@ func load(filename string) (map[string]string, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		tokens := strings.Split(line, "=")
+		tokens := strings.SplitN(line, "=", 2)
 
-		if len(tokens) != 2 {
+		if len(tokens) != 2 || len(tokens[0]) == 0 || len(tokens[1]) == 0 {
 			continue
 		} else if string(tokens[0][0]) == "#" || string(tokens[0][0]) == "//" {
 			continue

--- a/tests/comments_test.go
+++ b/tests/comments_test.go
@@ -11,7 +11,10 @@ func TestComments(t *testing.T) {
 		filename := filenames["comment"]
 
 		got, _ := dotenv.Config(filename, logger)
-		want := map[string]string{"KEY1": "VALUE1"}
+		want := map[string]string{
+			"KEY1":           "VALUE1",
+			"DB_CONN_STRING": "postgres://postgres:passw@localhost:5432/dbname?sslmode=disable",
+		}
 
 		reflectDeepEqual(t, got, want)
 	})
@@ -21,8 +24,9 @@ func TestComments(t *testing.T) {
 
 		got, _ := dotenv.Config(filename, logger)
 		want := map[string]string{
-			"KEY1": "VALUE1",
-			"KEY2": "VALUE2",
+			"KEY1":           "VALUE1",
+			"KEY2":           "VALUE2",
+			"DB_CONN_STRING": "postgres://postgres:passw@localhost:5432/dbname?sslmode=disable",
 		}
 
 		reflectDeepEqual(t, got, want)

--- a/tests/env/comments.env
+++ b/tests/env/comments.env
@@ -1,2 +1,3 @@
 KEY1=VALUE1
 #KEY2= VALUE2
+DB_CONN_STRING="postgres://postgres:passw@localhost:5432/dbname?sslmode=disable"

--- a/tests/env/inline-comment.env
+++ b/tests/env/inline-comment.env
@@ -1,2 +1,3 @@
 KEY1=VALUE1 //tesing
 KEY2=VALUE2 #tesing
+DB_CONN_STRING="postgres://postgres:passw@localhost:5432/dbname?sslmode=disable"

--- a/tests/env/valid.env
+++ b/tests/env/valid.env
@@ -1,2 +1,3 @@
 KEY1="VALUE1"
 KEY2=VALUE2
+DB_CONN_STRING="postgres://postgres:passw@localhost:5432/dbname?sslmode=disable"

--- a/tests/file_test.go
+++ b/tests/file_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestFile(t *testing.T) {
-
 	t.Run("Test valid file", func(t *testing.T) {
 		filename := filenames["valid"]
 
 		got, _ := dotenv.Config(filename, logger)
 		want := map[string]string{
-			"KEY1": "VALUE1",
-			"KEY2": "VALUE2",
+			"KEY1":           "VALUE1",
+			"KEY2":           "VALUE2",
+			"DB_CONN_STRING": "postgres://postgres:passw@localhost:5432/dbname?sslmode=disable",
 		}
 
 		reflectDeepEqual(t, got, want)
@@ -27,7 +27,7 @@ func TestFile(t *testing.T) {
 
 		dotenv.Config(filename, logger)
 		err := fmt.Sprintf("open %v: no such file or directory", filename)
-		
+
 		if !strings.Contains(logOutput.String(), err) {
 			t.Errorf("Expected %v got %v", err, logOutput.String())
 		}


### PR DESCRIPTION
This pull request resolves #2 .